### PR TITLE
Change bucket name to elastic-log-ingestion-control-tower

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/bucket_policy.json
+++ b/bucket_policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "serverlessrepo.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::elastic-log-ingestion-control-tower/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "${CHANGE TO YOUR ACCOUNT_ID}"
+        }
+      }
+    }
+  ]
+}

--- a/src/log-archive-account/elastic-core-resources-ingestion.yml
+++ b/src/log-archive-account/elastic-core-resources-ingestion.yml
@@ -1501,7 +1501,7 @@ Resources:
       Timeout: 300
       MemorySize: 128
       CodeUri:
-        Bucket: bootstrap-lambda-code
+        Bucket: elastic-log-ingestion-control-tower
         Key: LogArchive-code/Elastic-Log-Archive-BootstrapLambdaCode/ElasticBootstrapLambdaLogArchiveAccount.zip
       Environment:
         Variables:

--- a/src/member-account/elastic-ec2-log-ingestion.yml
+++ b/src/member-account/elastic-ec2-log-ingestion.yml
@@ -1022,7 +1022,7 @@ Resources:
       Timeout: 300
       MemorySize: 128
       Code:
-        S3Bucket: bootstrap-lambda-code
+        S3Bucket: elastic-log-ingestion-control-tower
         S3Key: LogArchive-code/Elastic-Log-Archive-BootstrapLambdaCode/ElasticBootstrapLambdaLogArchiveAccount.zip
       Environment:
         Variables:

--- a/src/member-account/helper-elastic-log-ingestion.yml
+++ b/src/member-account/helper-elastic-log-ingestion.yml
@@ -1213,7 +1213,7 @@ Resources:
       Timeout: 300
       MemorySize: 128
       CodeUri:
-        Bucket: bootstrap-lambda-code
+        Bucket: elastic-log-ingestion-control-tower
         Key: MemberAccount-code/ElasticBootstrapLambdaMemberAccount.zip
       Environment:
         Variables:
@@ -2135,7 +2135,7 @@ Resources:
                 stack_name = 'Elastic-Agent-' + random_suffix
                 
                 # Replace these values with your own
-                s3_bucket = 'elastic-proxy'
+                s3_bucket = 'elastic-log-ingestion-control-tower'
                 path = 'elastic-agent-ec2-metrics.json'
                 stack_name = stack_name
 

--- a/src/standalone-deployment/elastic-agent-ec2-metrics.json
+++ b/src/standalone-deployment/elastic-agent-ec2-metrics.json
@@ -189,7 +189,7 @@
                                 "export KIBANA_URL=$KIBANA_URL \n",
                                 "export DeploymentID=$DeploymentID \n",
                                 "export DeploymentVersion=$DeploymentVersion \n",
-                                "wget https://elastic-proxy.s3.amazonaws.com/elastic-agent.sh \n",
+                                "wget https://elastic-log-ingestion-control-tower.s3.eu-central-1.amazonaws.com/elastic-agent.sh \n",
                                 "sed -i -e ''s/\r$//'' elastic-agent.sh \n",
                                 "chmod +x elastic-agent.sh \n",
                                 "bash elastic-agent.sh \n"        

--- a/src/standalone-deployment/standalone-elastic-log-ingestion.yml
+++ b/src/standalone-deployment/standalone-elastic-log-ingestion.yml
@@ -1806,7 +1806,7 @@ Resources:
       Timeout: 900
       MemorySize: 128
       CodeUri:
-        Bucket: bootstrap-lambda-code
+        Bucket: elastic-log-ingestion-control-tower
         Key: Standalone-code/ElasticBootstrapLambdaStandaloneAccount.zip
       Environment:
         Variables:
@@ -2899,7 +2899,7 @@ Resources:
                 stack_name = 'Elastic-Agent-' + random_suffix
                 
                 # Replace these values with your own
-                s3_bucket = 'elastic-proxy'
+                s3_bucket = 'elastic-log-ingestion-control-tower'
                 path = 'elastic-agent-ec2-metrics.json'
                 stack_name = stack_name
 


### PR DESCRIPTION
This PR is to prepare publishing this application in SAR:
1. change bucket name to `elastic-log-ingestion-control-tower`
2. add policy.json for the S3 bucket
3. add license file

The bucket `elastic-log-ingestion-control-tower` is already created with the `eu-north-1` region (not necessary) with folders and zip files uploaded. 